### PR TITLE
feat: initial Oura → Roam Research export scaffolding

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -29,6 +29,12 @@ jobs:
         env:
           OURA_TOKEN: "${{ secrets.OURA_TOKEN }}"
         run: bb run:oura $START_DATE $END_DATE
+      # - name: Oura to Roam Research
+      #   env:
+      #     ROAM_GRAPH: "${{ secrets.ROAM_GRAPH }}"
+      #     ROAM_GRAPH_PASSWORD: "${{ secrets.ROAM_GRAPH_PASSWORD }}"
+      #     ROAM_API_TOKEN: "${{ secrets.ROAM_API_TOKEN }}"
+      #   run: bb run:roam-oura "$END_DATE"
       - name: Sync Wahoo data
         env:
           WAHOO_CLIENT_ID: "${{ secrets.WAHOO_CLIENT_ID }}"

--- a/AGENT.md
+++ b/AGENT.md
@@ -103,7 +103,6 @@ WAHOO_REFRESH_TOKEN=your_long_lived_refresh_token
 
 Configuration loader: `src/training_personal_data/config.clj` (reads env vars, validates presence).
 
-
 ### Wahoo OAuth bootstrap & persistence
 
 - Tokens are cached in Postgres (`wahoo_oauth_tokens`, columns: `id`, `provider`, `access_token`, `refresh_token`, `expires_at_epoch`, `raw_json`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Training Personal Data collects and analyzes personal health/fitness data, with 
 
 ```
 Oura API → ETL (bb tasks) → Postgres (normalized + raw JSON)
-                           → Weekly insights (SQL + GPT) → ouraring_weekly_insights
+                          → Weekly insights (SQL + GPT) → ouraring_weekly_insights
 ```
 
 ## 2.1) Architecture diagrams
@@ -87,6 +87,12 @@ SUPABASE_USER=postgres
 SUPABASE_PASSWORD=your_database_password
 SUPABASE_DB_NAME=your_database_name
 OPENAI_API_KEY=your_openai_api_key
+ROAM_API_TOKEN=your_roam_api_token
+ROAM_GRAPH=your_roam_graph_slug
+# Optional: only for encrypted graphs
+ROAM_GRAPH_PASSWORD=your_roam_graph_password
+# Optional: defaults to "oura"
+ROAM_PAGE_PREFIX=oura
 ```
 
 Wahoo OAuth auto-refresh (optional but recommended for CLI tasks):
@@ -131,6 +137,9 @@ Configuration loader: `src/training_personal_data/config.clj` (reads env vars, v
       `WAHOO_AUTH_CODE`, `WAHOO_REDIRECT_URI`
 - Generate weekly insights (for a date inside the target week):
   - `bb -m training-personal-data.insights.week YYYY-MM-DD`
+- Export Oura data to Roam (single date or range):
+  - `bb run:roam-oura "YYYY-MM-DD"`
+  - `bb run:roam-oura "YYYY-MM-DD" "YYYY-MM-DD"`
 - Run tests:
   - `bb test`
 
@@ -266,7 +275,29 @@ Persistence:
 - Ensure English-only text and structured logging
 - Open PR with clear title/summary (see example in previous PR templates)
 
-## 13) Roadmap (suggested)
+## 13) Roam Research Export
+
+- Namespace: `src/training_personal_data/export/roam.clj` orchestrates the data pull from Postgres, builds the bullet hierarchy, and synchronizes it with Roam.
+- Client: `src/training_personal_data/export/roam/api.clj` wraps the official backend API. It preserves the host advertised by Roam (`peer-XX`) and sends the required headers:
+  - `Authorization` / `x-authorization`: `Bearer <ROAM_API_TOKEN>`
+  - `x-graph`: graph slug (e.g., `avelino`)
+  - `x-graph-key`: graph password (only for encrypted graphs; omit otherwise)
+- Environment:
+  - Mandatory: `ROAM_API_TOKEN`, `ROAM_GRAPH`
+  - Optional (encrypted graphs): `ROAM_GRAPH_PASSWORD`
+  - Optional: `ROAM_PAGE_PREFIX` (defaults to `oura`)
+- Bullet layout:
+  - Root: `#ouraring [[November 29th, 2025]]`
+  - Children: `Sleep`, `Readiness`, `Activity`, `Heart rate`, `Workouts` (omitted when no data)
+  - Each child lists `Label: value` bullets or workout entries (`HH:MM – Activity (duration, calories, …)`).
+- State tracking: table `roam_exports` stores `id`, `page_uid`, block UID map, and a payload hash. The exporter skips updates when the hash matches.
+- CLI usage:
+  - `bb run:roam-oura 2025-11-29`
+  - `bb run:roam-oura 2025-11-01 2025-11-07`
+- Logs to monitor: `:roam-export-start`, `:roam-sync`, `:heart-rate-table-missing`, `:roam-cli-complete`, `:roam-cli-error`.
+- Security tips: keep Roam secrets in GitHub Actions secrets; never commit them. For curl/debugging, include the same headers the exporter sends.
+
+## 14) Roadmap (suggested)
 
 - Add monthly insights and trend analysis
 - Build lightweight dashboard (charts of scores/duration)

--- a/bb.edn
+++ b/bb.edn
@@ -33,6 +33,18 @@
                             (let [args *command-line-args*]
                               (shell (format "bb -cp src -m training-personal-data.insights.week %s"
                                              (first args)))))}
+  run:roam-oura {:doc "Export Oura data from Postgres to Roam pages"
+                 :task (do
+                         (println "\nExporting Oura data to Roam")
+                         (let [args *command-line-args*
+                               start (first args)
+                               end (or (second args) start)]
+                           (when (nil? start)
+                             (throw (ex-info "Usage: bb run:roam-oura <date> [<end-date>]" {})))
+                           (let [cmd (if (= start end)
+                                       (format "bb -cp src -m training-personal-data.export.roam %s" start)
+                                       (format "bb -cp src -m training-personal-data.export.roam %s %s" start end))]
+                             (shell cmd))))}
   run:wahoo {:doc "Run wahoo endpoint with date range (YYYY-MM-DD YYYY-MM-DD)"
              :task (do
                      (println "\nRun wahoo endpoint")

--- a/src/training_personal_data/config.clj
+++ b/src/training_personal_data/config.clj
@@ -13,3 +13,16 @@
                                    (dissoc :password)
                                    (assoc :password "[REDACTED]"))})))
     config))
+
+(defn get-roam-config []
+  (let [token (System/getenv "ROAM_API_TOKEN")
+        graph (System/getenv "ROAM_GRAPH")
+        graph-password (System/getenv "ROAM_GRAPH_PASSWORD")]
+    (when (and token graph)
+      {:token token
+       :graph graph
+       :page-prefix (or (System/getenv "ROAM_PAGE_PREFIX") "oura")
+       :graph-password graph-password})))
+
+(defn roam-enabled? []
+  (boolean (get-roam-config)))

--- a/src/training_personal_data/export/roam.clj
+++ b/src/training_personal_data/export/roam.clj
@@ -1,0 +1,411 @@
+(ns training-personal-data.export.roam
+  (:require [cheshire.core :as json]
+            [clojure.string :as str]
+            [taoensso.timbre :as log]
+            [training-personal-data.config :as config]
+            [training-personal-data.db :as common-db]
+            [training-personal-data.export.roam.api :as roam-api]
+            [training-personal-data.export.roam.db :as state-db]
+            [pod.babashka.postgresql :as pg])
+  (:import [java.nio.charset StandardCharsets]
+           [java.security MessageDigest]
+           [java.sql Date]
+           [java.time Duration Instant LocalDate LocalDateTime]
+           [java.time.format DateTimeFormatter]
+           [java.util Locale]))
+
+(def ^:private time-formatter (DateTimeFormatter/ofPattern "HH:mm"))
+
+(defn- bytes->hex [bytes]
+  (apply str (map #(format "%02x" (bit-and 0xff %)) bytes)))
+
+(defn- sha256 [value]
+  (let [digest (doto (MessageDigest/getInstance "SHA-256")
+                 (.update (.getBytes (str value) StandardCharsets/UTF_8)))]
+    (bytes->hex (.digest digest))))
+
+(defn- stable-uid [page-id segments]
+  (-> (sha256 (str page-id "|" (str/join "|" (map name segments))))
+      (subs 0 12)))
+
+(defn- parse-local-date [date-str]
+  (LocalDate/parse date-str))
+
+(defn- inclusive-date-range [start-date end-date]
+  (let [start (parse-local-date start-date)
+        end (parse-local-date end-date)]
+    (take-while #(not (.isAfter ^LocalDate % end))
+                (iterate #(.plusDays ^LocalDate % 1) start))))
+
+(defn- ordinal-suffix [day]
+  (let [mod-100 (mod day 100)]
+    (cond
+      (<= 11 mod-100 13) "th"
+      :else (case (mod day 10)
+              1 "st"
+              2 "nd"
+              3 "rd"
+              "th"))))
+
+(defn- format-roam-date [date-str]
+  (let [date (parse-local-date date-str)
+        formatter (DateTimeFormatter/ofPattern "MMMM" Locale/ENGLISH)
+        month (.format date formatter)
+        day (.getDayOfMonth date)
+        year (.getYear date)]
+    (format "%s %d%s, %d" month day (ordinal-suffix day) year)))
+
+(defn- minutes->hours [minutes]
+  (when (some? minutes)
+    (double (/ minutes 60.0))))
+
+(defn- format-decimal [value]
+  (when (some? value)
+    (format "%.1f" (double value))))
+
+(defn- fetch-single [db-spec sql date]
+  (first (common-db/query db-spec [sql date])))
+
+(defn- fetch-sleep [db-spec date]
+  (fetch-single db-spec
+                "SELECT score, total_sleep, efficiency, latency, deep_sleep,
+                        rem_sleep, restfulness, timestamp
+                 FROM ouraring_daily_sleep
+                 WHERE date = ?::date
+                 ORDER BY timestamp DESC
+                 LIMIT 1"
+                date))
+
+(defn- fetch-readiness [db-spec date]
+  (fetch-single db-spec
+                "SELECT score, temperature_trend, temperature_deviation
+                 FROM ouraring_daily_readiness
+                 WHERE date = ?::date
+                 LIMIT 1"
+                date))
+
+(defn- fetch-activity [db-spec date]
+  (fetch-single db-spec
+                "SELECT score, active_calories, steps, total_calories,
+                        daily_movement, non_wear_time, sedentary_time,
+                        target_calories
+                 FROM ouraring_daily_activity
+                 WHERE date = ?::date
+                 LIMIT 1"
+                date))
+
+(defn- fetch-heart-rate [db-spec date]
+  (let [sql "SELECT MIN(bpm) AS min_bpm,
+                        MAX(bpm) AS max_bpm,
+                        AVG(bpm) AS avg_bpm
+                 FROM ouraring_heart_rate
+                 WHERE date = ?::date"]
+    (try
+      (first (pg/execute! db-spec [sql date]))
+      (catch Exception e
+        (let [message (.getMessage e)]
+          (if (and message
+                   (re-find #"relation \"ouraring_heart_rate\" does not exist" message))
+            (do
+              (log/warn {:event :heart-rate-table-missing
+                         :msg "Skipping heart rate aggregation because table is missing"})
+              nil)
+            (throw e)))))))
+
+(defn- fetch-workouts [db-spec date]
+  (common-db/query db-spec
+                   ["SELECT id, activity, calories, start_datetime, end_datetime,
+                            intensity, label, source
+                     FROM ouraring_workout
+                     WHERE date = ?::date
+                     ORDER BY start_datetime"
+                    date]))
+
+(defn- collect-oura-data [db-spec date]
+  (let [sleep (fetch-sleep db-spec date)
+        readiness (fetch-readiness db-spec date)
+        activity (fetch-activity db-spec date)
+        heart-rate (fetch-heart-rate db-spec date)
+        workouts (fetch-workouts db-spec date)]
+    {:sleep (when sleep
+              {:score (:score sleep)
+               :duration_minutes (:total_sleep sleep)
+               :duration_hours (minutes->hours (:total_sleep sleep))
+               :efficiency (:efficiency sleep)
+               :deep_sleep (:deep_sleep sleep)
+               :rem_sleep (:rem_sleep sleep)
+               :latency (:latency sleep)
+               :restfulness (:restfulness sleep)})
+     :readiness (when readiness
+                  {:score (:score readiness)
+                   :temperature_trend (:temperature_trend readiness)
+                   :temperature_deviation (:temperature_deviation readiness)})
+     :activity (when activity
+                 {:score (:score activity)
+                  :active_calories (:active_calories activity)
+                  :steps (:steps activity)
+                  :total_calories (:total_calories activity)
+                  :daily_movement (:daily_movement activity)
+                  :sedentary_time (:sedentary_time activity)
+                  :non_wear_time (:non_wear_time activity)
+                  :target_calories (:target_calories activity)})
+     :heart-rate (when heart-rate
+                   {:min (:min_bpm heart-rate)
+                    :max (:max_bpm heart-rate)
+                    :avg (when-let [avg (:avg_bpm heart-rate)]
+                           (double avg))})
+     :workouts workouts}))
+
+(defn- format-time [^LocalDateTime dt]
+  (when dt
+    (.format dt time-formatter)))
+
+(defn- workout-duration-minutes [start end]
+  (when (and start end)
+    (.toMinutes (Duration/between start end))))
+
+(defn- workout-summary-string [{:keys [start_datetime end_datetime activity calories intensity label source]}]
+  (let [start (format-time start_datetime)
+        end (format-time end_datetime)
+        duration (workout-duration-minutes start_datetime end_datetime)
+        name (or label activity "Workout")
+        parts [(when (and start end)
+                 (str start " - " end))
+               (when duration
+                 (str duration " min"))
+               (when calories
+                 (str calories " kcal"))
+               (when intensity
+                 (str "intensity: " intensity))
+               (when source
+                 (str "source: " source))]]
+    (str name
+         (when-let [details (->> parts (remove nil?) seq)]
+           (str " (" (str/join ", " details) ")")))))
+
+(defn- block [key string & {:keys [children]}]
+  {:key key
+   :string string
+   :children (vec (or children []))})
+
+(defn- maybe-child [key label value suffix]
+  (when (some? value)
+    (block key (str label value suffix))))
+
+(defn- build-sleep-block [{:keys [sleep]}]
+  (when sleep
+    (let [children (->> [(maybe-child :sleep-score "Score: " (:score sleep) "")
+                         (when-let [duration (format-decimal (:duration_hours sleep))]
+                           (block :sleep-duration (str "Duration: " duration " h")))
+                         (maybe-child :sleep-efficiency "Efficiency: " (:efficiency sleep) "%")
+                         (maybe-child :sleep-deep "Deep sleep: " (:deep_sleep sleep) " min")
+                         (maybe-child :sleep-rem "REM sleep: " (:rem_sleep sleep) " min")
+                         (maybe-child :sleep-latency "Latency: " (:latency sleep) " min")
+                         (maybe-child :sleep-restfulness "Restfulness: " (:restfulness sleep) "")]
+                        (remove nil?)
+                        vec)]
+      (when (seq children)
+        (block :sleep "Sleep" :children children)))))
+
+(defn- build-readiness-block [{:keys [readiness]}]
+  (when readiness
+    (let [children (->> [(maybe-child :readiness-score "Score: " (:score readiness) "")
+                         (maybe-child :readiness-temp-trend "Temperature trend: "
+                                      (some-> (:temperature_trend readiness) format-decimal) " °C")
+                         (maybe-child :readiness-temp-dev "Temperature deviation: "
+                                      (some-> (:temperature_deviation readiness) format-decimal) " °C")]
+                        (remove nil?)
+                        vec)]
+      (when (seq children)
+        (block :readiness "Readiness" :children children)))))
+
+(defn- build-activity-block [{:keys [activity]}]
+  (when activity
+    (let [children (->> [(maybe-child :activity-score "Score: " (:score activity) "")
+                         (maybe-child :activity-active-calories "Active calories: " (:active_calories activity) " kcal")
+                         (maybe-child :activity-steps "Steps: " (:steps activity) "")
+                         (maybe-child :activity-total-calories "Total calories: " (:total_calories activity) " kcal")
+                         (maybe-child :activity-daily-movement "Daily movement: " (:daily_movement activity) " au")
+                         (maybe-child :activity-sedentary "Sedentary time: " (:sedentary_time activity) " min")
+                         (maybe-child :activity-non-wear "Non-wear time: " (:non_wear_time activity) " min")
+                         (maybe-child :activity-target-calories "Target calories: " (:target_calories activity) " kcal")]
+                        (remove nil?)
+                        vec)]
+      (when (seq children)
+        (block :activity "Activity" :children children)))))
+
+(defn- build-heart-rate-block [{:keys [heart-rate]}]
+  (when heart-rate
+    (let [children (->> [(maybe-child :heartrate-min "Resting: " (:min heart-rate) " bpm")
+                         (maybe-child :heartrate-avg "Average: "
+                                      (some-> (:avg heart-rate) format-decimal) " bpm")
+                         (maybe-child :heartrate-max "Max: " (:max heart-rate) " bpm")]
+                        (remove nil?)
+                        vec)]
+      (when (seq children)
+        (block :heart-rate "Heart rate" :children children)))))
+
+(defn- build-workouts-block [{:keys [workouts]}]
+  (when (seq workouts)
+    (let [children (->> workouts
+                        (map-indexed
+                         (fn [idx workout]
+                           (block (keyword (str "workout-" idx))
+                                  (workout-summary-string workout))))
+                        vec)]
+      (block :workouts "Workouts" :children children))))
+
+(defn- build-blocks [date data]
+  (let [sections (remove nil?
+                         [(build-sleep-block data)
+                          (build-readiness-block data)
+                          (build-activity-block data)
+                          (build-heart-rate-block data)
+                          (build-workouts-block data)])
+        children (if (seq sections)
+                   sections
+                   [(block :status "No Oura data available for this date.")])]
+    [(block :header
+            (str "#ouraring [[" (format-roam-date date) "]]")
+            :children children)]))
+
+(defn- ensure-page! [conn title desired-uid]
+  (let [query "[:find ?uid :in $ ?title :where [?p :node/title ?title] [?p :block/uid ?uid]]"
+        result (roam-api/q conn query title)
+        existing-uid (some-> result first first)]
+    (if existing-uid
+      {:uid existing-uid :created? false}
+      (do
+        (log/info {:event :roam-create-page
+                   :title title
+                   :uid desired-uid})
+        (roam-api/create-page conn title {:uid desired-uid})
+        {:uid desired-uid :created? true}))))
+
+(defn- upsert-blocks!
+  [conn page-id parent-uid blocks existing-state path]
+  (reduce
+   (fn [acc [idx block]]
+     (let [parent-state (or existing-state {:children {}})
+           block-key (:key block)
+           next-path (conj path block-key)
+           stored (get-in parent-state [:children block-key])
+           block-uid (or (:uid stored)
+                         (stable-uid page-id next-path))]
+       (when (nil? (:string block))
+         (throw (ex-info "Block string cannot be nil" {:key block-key})))
+       (if stored
+         (do
+           (roam-api/update-block conn {:uid block-uid
+                                        :string (:string block)})
+           (roam-api/move-block conn {:uid block-uid
+                                      :parent-uid parent-uid
+                                      :order idx}))
+         (do
+           (log/info {:event :roam-create-block
+                      :parent parent-uid
+                      :uid block-uid
+                      :order idx
+                      :title (:string block)})
+           (roam-api/create-block conn {:parent-uid parent-uid
+                                        :order idx}
+                                  {:uid block-uid
+                                   :string (:string block)})))
+       (let [children (:children block)
+             child-state (upsert-blocks! conn page-id block-uid children stored next-path)]
+         (assoc acc block-key {:uid block-uid
+                               :children child-state}))))
+   {}
+   (map-indexed vector blocks)))
+
+(defn- sync-page-content!
+  [conn page-id page-uid blocks existing-state]
+  (let [state (or existing-state {:uid page-uid :children {}})
+        children-state (upsert-blocks! conn page-id page-uid blocks state [])]
+    {:uid page-uid
+     :children children-state}))
+
+(defn- now-inst []
+  (Instant/now))
+
+(defn- export-day!
+  [{:keys [token graph page-prefix graph-password]} db-spec date existing-state]
+  (log/info {:event :roam-export-start
+             :date date})
+  (let [data (collect-oura-data db-spec date)
+        blocks (build-blocks date data)
+        content-hash (sha256 (json/generate-string {:data data
+                                                    :blocks blocks}))
+        export-id (str page-prefix "-" date)
+        page-title (str page-prefix "/" date)
+        page-id export-id
+        roam-conn {:token token
+                   :graph graph
+                   :graph-password graph-password}
+        desired-page-uid (or (:page_uid existing-state)
+                             (stable-uid page-id [:page]))
+        {:keys [uid created?]} (ensure-page! roam-conn page-title desired-page-uid)
+        state-changed? (or (nil? existing-state)
+                           created?
+                           (not= content-hash (:content_hash existing-state)))
+        block-state (if state-changed?
+                      (sync-page-content! roam-conn page-id uid blocks (:block_uids existing-state))
+                      (:block_uids existing-state))
+        record {:id export-id
+                :date (Date/valueOf date)
+                :page_uid uid
+                :block_uids (or block-state {:uid uid :children {}})
+                :content_hash content-hash
+                :metadata_json {:oura data
+                                :synced_at (str (now-inst))
+                                :status (if state-changed? "updated" "noop")}}]
+    (when state-changed?
+      (log/info {:event :roam-sync
+                 :date date
+                 :created created?
+                 :content-hash content-hash}))
+    (state-db/save-export! db-spec record)
+    {:status (if state-changed? :updated :skipped)
+     :date date
+     :page_uid uid
+     :hash content-hash}))
+
+(defn export-range!
+  [conn db-spec start-date end-date]
+  (state-db/ensure-table! db-spec)
+  (let [dates (inclusive-date-range start-date end-date)]
+    (mapv (fn [date]
+            (let [date-str (.toString ^LocalDate date)
+                  export-id (str (:page-prefix conn) "-" date-str)
+                  existing (state-db/get-export db-spec export-id)]
+              (export-day! conn db-spec date-str existing)))
+          dates)))
+
+(defn- parse-args [args]
+  (case (count args)
+    1 {:start (first args) :end (first args)}
+    2 {:start (first args) :end (second args)}
+    (throw (ex-info "Usage: bb -m training-personal-data.export.roam <date> [<end-date>]"
+                    {:args args}))))
+
+(defn -main [& args]
+  (try
+    (let [{:keys [start end]} (parse-args args)
+          _ (log/info {:event :roam-cli-start
+                       :start start
+                       :end end})
+          db-spec (common-db/make-db-spec (config/get-db-config))
+          roam-config (config/get-roam-config)]
+      (when-not roam-config
+        (throw (ex-info "Missing Roam configuration"
+                        {:required ["ROAM_API_TOKEN" "ROAM_GRAPH"]})))
+      (export-range! roam-config db-spec start end)
+      (log/info {:event :roam-cli-complete
+                 :start start
+                 :end end}))
+    (catch Exception e
+      (log/error {:event :roam-cli-error
+                  :error (ex-message e)
+                  :data (ex-data e)})
+      (println "Roam export failed:" (ex-message e))
+      (System/exit 1))))

--- a/src/training_personal_data/export/roam/api.clj
+++ b/src/training_personal_data/export/roam/api.clj
@@ -1,0 +1,132 @@
+(ns training-personal-data.export.roam.api
+  (:require [babashka.http-client :as http]
+            [clojure.string :as str]
+            [cheshire.core :as json]
+            [taoensso.timbre :as log]))
+
+(def ^:private frontdesk-url "https://api.roamresearch.com")
+(defonce ^:private graph-base-urls (atom {}))
+
+(defn- build-base-url [^String location]
+  (let [uri (java.net.URI. location)
+        port (.getPort uri)
+        port-str (when (and port (pos? port)) (str ":" port))]
+    (str (.getScheme uri) "://" (.getHost uri) (or port-str ""))))
+
+(defn- request
+  "Performs a request against the Roam API and returns the parsed body or throws
+   on non-successful status codes. Handles redirects to Roam peer endpoints."
+  [{:keys [token graph graph-password]} path method body]
+  (let [payload (when (some? body) (json/generate-string body))
+        headers (cond-> {"Content-Type" "application/json; charset=utf-8"
+                         "Authorization" (str "Bearer " token)
+                         "x-authorization" (str "Bearer " token)
+                         "x-graph" graph}
+                  (some? graph-password) (assoc "x-graph-key" graph-password))]
+    (loop [attempt 0
+           base-url (get @graph-base-urls graph frontdesk-url)]
+      (let [url (str base-url path)
+            response (http/request {:uri url
+                                    :method method
+                                    :headers headers
+                                    :body payload
+                                    :throw false
+                                    :redirect-policy :never})
+            status (:status response)]
+        (log/debug {:event :roam-api-request
+                    :path path
+                    :status status
+                    :base-url base-url})
+        (cond
+          (and (#{301 302 307 308} status) (< attempt 3))
+          (if-let [location (or (get-in response [:headers "location"])
+                                (get-in response [:headers "Location"]))]
+            (let [new-base (build-base-url location)]
+              (swap! graph-base-urls assoc graph new-base)
+              (recur (inc attempt) new-base))
+            (throw (ex-info "Roam API redirected without location header"
+                            {:path path :status status})))
+
+          (<= 200 status 299)
+          (if-let [resp-body (:body response)]
+            (if (str/blank? resp-body)
+              {}
+              (json/parse-string resp-body true))
+            {})
+
+          (= status 400)
+          (throw (ex-info "Roam API returned 400" {:path path :method method :body (:body response)}))
+
+          (= status 401)
+          (throw (ex-info "Roam API rejected credentials" {:path path :method method}))
+
+          (= status 403)
+          (throw (ex-info "Roam API forbidden" {:path path :method method}))
+
+          (= status 503)
+          (throw (ex-info "Roam graph not ready yet" {:path path :method method}))
+
+          :else
+          (throw (ex-info "Unexpected Roam API response"
+                          {:path path :method method :status status :body (:body response)})))))))
+
+(defn- write-path [graph]
+  (str "/api/graph/" graph "/write"))
+
+(defn- pull-path [graph]
+  (str "/api/graph/" graph "/pull"))
+
+(defn- pull-many-path [graph]
+  (str "/api/graph/" graph "/pull-many"))
+
+(defn- query-path [graph]
+  (str "/api/graph/" graph "/q"))
+
+(defn do-command [conn cmd]
+  (request conn (write-path (:graph conn)) :post cmd))
+
+(defn batch
+  "Executes a batch of write commands."
+  [conn & cmds]
+  (do-command conn {:action :batch-actions
+                    :actions cmds}))
+
+(defn create-page [conn title page]
+  (do-command conn {:action :create-page
+                    :page (-> page
+                              (select-keys [:uid :children-view-type])
+                              (assoc :title title))}))
+
+(defn update-page [conn uid page]
+  (do-command conn {:action :update-page
+                    :page (-> page
+                              (select-keys [:title :children-view-type])
+                              (assoc :uid uid))}))
+
+(defn create-block [conn location block]
+  (do-command conn {:action :create-block
+                    :location (select-keys location [:parent-uid :order])
+                    :block (select-keys block
+                                        [:uid :open :heading :text-align :children-view-type :string])}))
+
+(defn update-block [conn block]
+  (do-command conn {:action :update-block
+                    :block (select-keys block
+                                        [:uid :open :heading :text-align :children-view-type :string])}))
+
+(defn move-block [conn location]
+  (do-command conn {:action :move-block
+                    :location (select-keys location
+                                           [:parent-uid :uid :order])}))
+
+(defn q [conn query & args]
+  (:result (request conn (query-path (:graph conn)) :post {:query query
+                                                           :args args})))
+
+(defn pull [conn selector eid]
+  (request conn (pull-path (:graph conn)) :post {:selector selector
+                                                 :eid eid}))
+
+(defn pull-many [conn selector eids]
+  (request conn (pull-many-path (:graph conn)) :post {:selector selector
+                                                      :eids eids}))

--- a/src/training_personal_data/export/roam/db.clj
+++ b/src/training_personal_data/export/roam/db.clj
@@ -1,0 +1,51 @@
+(ns training-personal-data.export.roam.db
+  (:require [cheshire.core :as json]
+            [training-personal-data.db :as common-db]
+            [pod.babashka.postgresql :as pg]
+            [taoensso.timbre :as log]))
+
+(def table-name "roam_exports")
+
+(def columns
+  ["id" "date" "page_uid" "block_uids" "content_hash" "metadata_json"])
+
+(def schema
+  {:id [:text :primary-key]
+   :date [:date]
+   :page_uid :text
+   :block_uids :jsonb
+   :content_hash :text
+   :metadata_json :jsonb
+   :last_synced_at [:timestamp :default "CURRENT_TIMESTAMP"]})
+
+(defn ensure-table! [db-spec]
+  (log/info {:event :db-create-table
+             :table table-name
+             :msg "Ensuring Roam export state table exists"})
+  (common-db/create-table db-spec table-name schema))
+
+(defn- encode-json [data]
+  (when (some? data)
+    (json/generate-string data)))
+
+(defn extract-values [{:keys [id date page_uid block_uids content_hash metadata_json]}]
+  [id
+   date
+   page_uid
+   (encode-json block_uids)
+   content_hash
+   (encode-json metadata_json)])
+
+(defn save-export! [db-spec record]
+  (log/info {:event :db-save
+             :table table-name
+             :id (:id record)
+             :msg "Persisting Roam export state"})
+  (common-db/save db-spec table-name columns record (extract-values record)))
+
+(defn get-export [db-spec export-id]
+  (some-> (pg/execute! db-spec
+                       [(str "SELECT * FROM " table-name " WHERE id = ?") export-id])
+          first
+          (update :block_uids #(some-> % (json/parse-string true)))
+          (update :metadata_json #(some-> % (json/parse-string true)))))

--- a/src/training_personal_data/ouraring.clj
+++ b/src/training_personal_data/ouraring.clj
@@ -7,6 +7,7 @@
             [training-personal-data.ouraring.config :as oura-config]
             [training-personal-data.core.pipeline :as pipeline]
             [training-personal-data.db :as db]
+            [training-personal-data.export.roam :as roam-export]
             [taoensso.timbre :as log]))
 
 (defn validate-env []
@@ -192,7 +193,17 @@
               (when (seq failed)
                 (println "\n⚠️  Some endpoints failed:")
                 (doseq [failure failed]
-                  (println "  -" (:endpoint failure) ":" (:error failure))))))))
+                  (println "  -" (:endpoint failure) ":" (:error failure))))
+
+              (when (empty? failed)
+                (if-let [roam-config (config/get-roam-config)]
+                  (do
+                    (log/info {:event :roam-export-trigger
+                               :start start-date
+                               :end end-date})
+                    (roam-export/export-range! roam-config db-spec start-date end-date))
+                  (log/info {:event :roam-export-skip
+                             :reason "Missing Roam configuration"})))))))
 
       (log/info {:event :complete :msg "Successfully completed Oura Ring data sync"}))
 


### PR DESCRIPTION
- Adds Roam Research export pipeline: modules for API, DB, and ETL orchestration under `src/training_personal_data/export/roam.clj` and submodules.
- Updates GitHub Actions workflow (`cron.yml`) with commented example for Oura→Roam export step and secret env vars (`ROAM_GRAPH`, `ROAM_GRAPH_PASSWORD`, `ROAM_API_TOKEN`).
- Configures main project (`bb.edn`) for new export tasks.
- Expands configuration loader to support Roam-specific env vars.
- Documentation: extends AGENT.md with roadmap and environmental sections for Roam export.

Scaffolds the Roam integration, but does not yet trigger automatic exports. Enables future work for seamless daily/weekly Oura → Roam note publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Export Oura health metrics directly to Roam Research with support for single-date and date-range exports.
  * Added CLI commands for automated Roam export scheduling.

* **Documentation**
  * Updated configuration guide with Roam API setup and environment variable requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->